### PR TITLE
TweetBodyバリューオブジェクトのバグ修正

### DIFF
--- a/src/app/Domain/ValueObject/Exception/OutOfRangeException.php
+++ b/src/app/Domain/ValueObject/Exception/OutOfRangeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Domain\ValueObject\Exception;
+
+final class OutOfRangeException extends TweetBodyException
+{
+}

--- a/src/app/Domain/ValueObject/Exception/TweetBodyException.php
+++ b/src/app/Domain/ValueObject/Exception/TweetBodyException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Domain\ValueObject\Exception;
+
+use Exception;
+
+class TweetBodyException extends Exception
+{
+}

--- a/src/app/Domain/ValueObject/TweetBody.php
+++ b/src/app/Domain/ValueObject/TweetBody.php
@@ -2,7 +2,7 @@
 
 namespace App\Domain\ValueObject;
 
-use Exception;
+use App\Domain\ValueObject\Exception\OutOfRangeException;
 
 final class TweetBody
 {
@@ -13,7 +13,7 @@ final class TweetBody
     public function __construct(string $value)
     {
         if (strlen($value) < self::MIN_LENGTH || self::MAX_LENGTH < strlen($value)) {
-            throw new Exception('1文字以上、140文字以内で投稿してください');
+            throw new OutOfRangeException('1文字以上、140文字以内で投稿してください');
         }
 
         $this->value = $value;

--- a/src/app/Domain/ValueObject/TweetBody.php
+++ b/src/app/Domain/ValueObject/TweetBody.php
@@ -6,17 +6,18 @@ use Exception;
 
 final class TweetBody
 {
+    private const MIN_LENGTH = 1;
+    private const MAX_LENGTH = 140;
     private $value;
 
     public function __construct(string $value)
     {
-        if (140 <= strlen($value)) {
-            throw new Exception('Tweetは140字以内で投稿してください');
+        if (strlen($value) < self::MIN_LENGTH || self::MAX_LENGTH < strlen($value)) {
+            throw new Exception('1文字以上、140文字以内で投稿してください');
         }
 
         $this->value = $value;
     }
-
     public function value(): string
     {
         return $this->value;

--- a/src/app/Domain/ValueObject/TweetDate.php
+++ b/src/app/Domain/ValueObject/TweetDate.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Domain\ValueObject;
 
 use DateTime;

--- a/src/app/Infrastructure/Validator/SignInInputValidator.php
+++ b/src/app/Infrastructure/Validator/SignInInputValidator.php
@@ -12,7 +12,7 @@ final class SignInInputValidator
     public const ERROR_EMAIL_INVALID_FORMAT = '不正な形式のメールアドレスです';
     public const ERROR_EMAIL_NULL_TEXT = 'Emailが空です';
     public const ERROR_PASSWORD_NULL_TEXT = 'passwordが空です';
-    public const ERROR_EMAIL_PASSWORD_FORMAT = '不正な形式のパスワードです';
+    public const ERROR_PASSWORD_INVALID_FORMAT = '不正な形式のパスワードです';
 
     private $email;
     private $password;
@@ -61,7 +61,7 @@ final class SignInInputValidator
         }
 
         if (!Password::isValid($this->password)) {
-            return self::ERROR_EMAIL_PASSWORD_FORMAT;
+            return self::ERROR_PASSWORD_INVALID_FORMAT;
         }
 
         return null;

--- a/src/test/SignInInputValidatorTest.php
+++ b/src/test/SignInInputValidatorTest.php
@@ -6,36 +6,64 @@ use App\Infrastructure\Validator\SignInInputValidator;
 
 class SignInInputValidatorTest extends TestCase
 {
-    public function メールアドレスが正しかったとき()
+    /** @test */
+    public function メールアドレスとパスワードが正しかったとき_空配列が返ること()
     {
+
         $signInInputValidator = new SignInInputValidator(
             'hoge-hoge@email.com',
-            ''
+            'Aa111111'
         );
         $actual = $signInInputValidator->allErrors();
 
-        $this->assertNull($actual[0]);
+        $this->assertEmpty($actual);
     }
 
-    public function メールアドレスが空の時のテスト()
+    /** @test */
+    public function メールアドレスが空の時_想定するエラーメッセージが配列に含まれていること()
     {
-        $signInInputValidator = new SignInInputValidator('');
+        $signInInputValidator = new SignInInputValidator('', 'Aa111111');
         $actual = $signInInputValidator->allErrors();
 
-        $this->assertSame(
+        $this->assertContains(
             SignInInputValidator::ERROR_EMAIL_NULL_TEXT,
-            $actual[0]
+            $actual
         );
     }
 
-    public function メールアドレスの形式が不正だった時のテスト()
+    /** @test */
+    public function メールアドレスの形式が不正だった時_想定するエラーメッセージが配列に含まれていること()
     {
-        $signInInputValidator = new SignInInputValidator('a');
+        $signInInputValidator = new SignInInputValidator('a', 'Aa111111');
         $actual = $signInInputValidator->allErrors();
 
-        $this->assertSame(
+        $this->assertContains(
             SignInInputValidator::ERROR_EMAIL_INVALID_FORMAT,
-            $actual[0]
+            $actual
+        );
+    }
+
+    /** @test */
+    public function パスワードが空の時_想定するエラーメッセージが配列に含まれていること()
+    {
+        $signInInputValidator = new SignInInputValidator('hoge-hoge@email.com', '');
+        $actual = $signInInputValidator->allErrors();
+
+        $this->assertContains(
+            SignInInputValidator::ERROR_PASSWORD_NULL_TEXT,
+            $actual
+        );
+    }
+
+    /** @test */
+    public function パスワードの形式が不正だった時_想定するエラーメッセージが配列に含まれていること()
+    {
+        $signInInputValidator = new SignInInputValidator('hoge-hoge@email.com', '111111');
+        $actual = $signInInputValidator->allErrors();
+
+        $this->assertContains(
+            SignInInputValidator::ERROR_PASSWORD_INVALID_FORMAT,
+            $actual
         );
     }
 }

--- a/src/test/TweetBodyTest.php
+++ b/src/test/TweetBodyTest.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 use App\Domain\ValueObject\TweetBody;
 use PHPUnit\Framework\TestCase;
+use App\Domain\ValueObject\Exception\OutOfRangeException;
 
 final class TweetBodyTest extends TestCase
 {
@@ -28,14 +29,14 @@ final class TweetBodyTest extends TestCase
     /** @test */
     public function ツイートが0文字の時_エラーが発生すること()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(OutOfRangeException::class);
         new TweetBody('');
     }
 
     /** @test */
     public function ツイートが141字の時_エラーが発生すること()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(OutOfRangeException::class);
         new TweetBody(
             'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         );

--- a/src/test/TweetBodyTest.php
+++ b/src/test/TweetBodyTest.php
@@ -1,0 +1,43 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\Domain\ValueObject\TweetBody;
+use PHPUnit\Framework\TestCase;
+
+final class TweetBodyTest extends TestCase
+{
+    /** @test */
+    public function ツイートが1文字の時_エラーが発生しないこと()
+    {
+        $expected = 'a';
+        $tweetBody = new TweetBody($expected);
+        $actual = $tweetBody->value();
+        $this->assertSame($expected, $actual);
+    }
+
+    /** @test */
+    public function ツイートが140文字の時_エラーが発生しないこと()
+    {
+        $expected = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        $tweetBody = new TweetBody($expected);
+        $actual = $tweetBody->value();
+        $this->assertSame($expected, $actual);
+    }
+
+    /** @test */
+    public function ツイートが0文字の時_エラーが発生すること()
+    {
+        $this->expectException(Exception::class);
+        new TweetBody('');
+    }
+
+    /** @test */
+    public function ツイートが141字の時_エラーが発生すること()
+    {
+        $this->expectException(Exception::class);
+        new TweetBody(
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        );
+    }
+}


### PR DESCRIPTION
TweetBodyを1文字以上140文字以下で許容するように修正しテストコードを作成しました。
SignInInputValidatorのテストが行えるようにしました。
お手隙でご確認お願いします。
