### PR TITLE
【Issue #131】GetTweetDetailInteractorのテストコードの作成

### DIFF
--- a/src/app/Adapter/QueryService/TweetQueryService.php
+++ b/src/app/Adapter/QueryService/TweetQueryService.php
@@ -33,7 +33,7 @@ final class TweetQueryService implements TweetQueryServiceInterface
             new ReplyTweetId($tweetMapper['reply_tweet_id']),
             new TweetDevice($tweetMapper['device']),
             new TweetDate($tweetMapper['created_at']),
-            new DateTime($tweetMapper['deleted_at'])
+            $tweetMapper['deleted_at'] ? new DateTime($tweetMapper['deleted_at']) : null
         );
     }
 

--- a/src/app/Adapter/QueryService/TweetQueryService.php
+++ b/src/app/Adapter/QueryService/TweetQueryService.php
@@ -4,6 +4,7 @@ namespace App\Adapter\QueryService;
 
 use DateTime;
 use App\Infrastructure\Dao\TweetDao;
+use App\Domain\Adapter\TweetQueryServiceInterface;
 use App\Domain\Entity\Tweet;
 use App\Domain\ValueObject\TweetId;
 use App\Domain\ValueObject\UserId;
@@ -12,7 +13,7 @@ use App\Domain\ValueObject\ReplyTweetId;
 use App\Domain\ValueObject\TweetDevice;
 use App\Domain\ValueObject\TweetDate;
 
-final class TweetQueryService
+final class TweetQueryService implements TweetQueryServiceInterface
 {
     private $tweetDao;
 

--- a/src/app/Domain/Adapter/TweetQueryServiceInterface.php
+++ b/src/app/Domain/Adapter/TweetQueryServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Domain\Adapter;
+
+use App\Domain\Entity\Tweet;
+use App\Domain\ValueObject\UserId;
+use App\Domain\ValueObject\TweetId;
+
+interface TweetQueryServiceInterface
+{
+  public function findById(TweetId $id): Tweet;
+  public function findAllByUserId(UserId $userId): array;
+}

--- a/src/app/UseCase/GetTweetDetail/GetTweetDetail.php
+++ b/src/app/UseCase/GetTweetDetail/GetTweetDetail.php
@@ -2,8 +2,10 @@
 
 namespace App\UseCase\GetTweetDetail;
 
+use App\Domain\Adapter\TweetQueryServiceInterface;
+
 interface GetTweetDetail
 {
-    public function __construct(GetTweetDetailInput $input);
+    public function __construct(GetTweetDetailInput $input, TweetQueryServiceInterface $tweetQuery);
     public function handler(): GetTweetDetailOutput;
 }

--- a/src/app/UseCase/GetTweetDetail/GetTweetDetailInteractor.php
+++ b/src/app/UseCase/GetTweetDetail/GetTweetDetailInteractor.php
@@ -2,14 +2,14 @@
 
 namespace App\UseCase\GetTweetDetail;
 
-use App\Adapter\QueryService\TweetQueryService;
 use App\UseCase\GetTweetDetail\GetTweetDetailInput;
 use App\UseCase\GetTweetDetail\GetTweetDetailOutput;
+use App\Domain\Adapter\TweetQueryServiceInterface;
 
 final class GetTweetDetailInteractor implements GetTweetDetail
 {
     /**
-     * @var TweetQueryService
+     * @var TweetQueryServiceInterface
      */
     private $tweetQueryService;
 
@@ -18,9 +18,9 @@ final class GetTweetDetailInteractor implements GetTweetDetail
      */
     private $input;
 
-    public function __construct(GetTweetDetailInput $input)
+    public function __construct(GetTweetDetailInput $input, TweetQueryServiceInterface $tweetQuery)
     {
-        $this->tweetQueryService = new TweetQueryService();
+        $this->tweetQueryService = $tweetQuery;
         $this->input = $input;
     }
 

--- a/src/public/status.php
+++ b/src/public/status.php
@@ -4,11 +4,12 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use App\UseCase\GetTweetDetail\GetTweetDetailInteractor;
 use App\UseCase\GetTweetDetail\GetTweetDetailInput;
 use App\Domain\ValueObject\TweetId;
+use App\Adapter\QueryService\TweetQueryService;
 
 $tweetId = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
 
 $input = new GetTweetDetailInput(new TweetId($tweetId));
-$useCase = new GetTweetDetailInteractor($input);
+$useCase = new GetTweetDetailInteractor($input, new TweetQueryService());
 $output = $useCase->handler();
 $tweet = $output->tweet();
 ?>
@@ -26,13 +27,13 @@ $tweet = $output->tweet();
       <h1>ツイート詳細ページ</h1>
       <div class="tweet-status">
         <p class="tweet-status__tweet"><?php echo $tweet
-            ->tweetBody()
-            ->value(); ?></p>
+                                          ->tweetBody()
+                                          ->value(); ?></p>
         <p class="tweet-status__date"><?php echo $tweet->createdAt()->date() .
-            '・' .
-            'Twitter for' .
-            ' ' .
-            $tweet->device()->value(); ?></p>
+                                        '・' .
+                                        'Twitter for' .
+                                        ' ' .
+                                        $tweet->device()->value(); ?></p>
       </div>
       <div class="tweet-button">
         <span class="share-link">Reply</span>

--- a/src/test/GetTweetDetailTest.php
+++ b/src/test/GetTweetDetailTest.php
@@ -2,16 +2,48 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use App\UseCase\GetTweetDetail\GetTweetDetailInput;
+use App\UseCase\GetTweetDetail\GetTweetDetailInteractor;
+use App\Domain\Adapter\TweetQueryServiceInterface;
 use App\Domain\ValueObject\TweetId;
+use App\Domain\ValueObject\UserId;
+use App\Domain\ValueObject\TweetBody;
+use App\Domain\ValueObject\TweetDevice;
+use App\Domain\ValueObject\TweetDate;
+use App\Domain\Entity\Tweet;
 use PHPUnit\Framework\TestCase;
 
-final class SigninTest extends TestCase
+final class GetTweetDetailTest extends TestCase
 {
   /** @test */
-  public function tweetIdが存在する場合tweetが取得されていること()
+  public function tweetIdが存在する場合tweetEntityが取得されていること()
   {
     $usecaseInput = new GetTweetDetailInput(
-      new TweetId('test')
+      new TweetId(1)
     );
+    $usecaseInteractor = new GetTweetDetailInteractor(
+      $usecaseInput,
+      new class implements TweetQueryServiceInterface
+      {
+        public function findById(TweetId $id): Tweet
+        {
+          return new Tweet(
+            new TweetId(1),
+            new UserId(1),
+            new TweetBody('test'),
+            null,
+            new TweetDevice('test'),
+            new TweetDate('2022-07-22 20:37:04'),
+            null,
+          );
+        }
+
+        public function findAllByUserId(UserId $userId): array
+        {
+          return [];
+        }
+      }
+    );
+    $usecaseOutput = $usecaseInteractor->handler();
+    $this->assertTrue($usecaseOutput->tweet() instanceof Tweet);
   }
 }

--- a/src/test/GetTweetDetailTest.php
+++ b/src/test/GetTweetDetailTest.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\UseCase\GetTweetDetail\GetTweetDetailInput;
+use App\Domain\ValueObject\TweetId;
+use PHPUnit\Framework\TestCase;
+
+final class SigninTest extends TestCase
+{
+  /** @test */
+  public function tweetIdが存在する場合tweetが取得されていること()
+  {
+    $usecaseInput = new GetTweetDetailInput(
+      new TweetId('test')
+    );
+  }
+}


### PR DESCRIPTION
## 作業概要
- Testを実装するにあたって `TweetQueryServiceInterface` を作成
- Queryサービスを `TweetQueryServiceInterface` に依存させる形式に変更
- Testを作成

## 確認事項
現在の `GetTweetDetailInteractor` の実装だと、必ずTweetが取得される前提になっています。
そのため、「存在しない `TweetId` が指定された場合」といったテストが必要かなと思いましたが、現時点では実装していません。
ページの遷移的には基本的に表示されているツイートをクリック -> 詳細ページへとなるので、基本的に存在しているはずだとは思いますが、ユーザー操作が複雑な場合に存在しないツイートを取得しようとするパターンは発生すると個人的には思いました。

上記必要であれば対応しますので、ご確認をお願いします。 (別チケットのほうが良いかも？)
また、その他実装すべきテストパターンなどあれば合わせてご指摘いただければと思います。